### PR TITLE
Add tag name in ref

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -2,7 +2,7 @@
 function get_git_status -d "Gets the current git status"
   if command git rev-parse --is-inside-work-tree >/dev/null 2>&1
     set -l dirty (command git status -s --ignore-submodules=dirty | wc -l | sed -e 's/^ *//' -e 's/ *$//' 2> /dev/null)
-    set -l ref (command git symbolic-ref --short HEAD 2> /dev/null ; or command git rev-parse --short HEAD 2> /dev/null)
+    set -l ref (command git describe --tags --exact-match ^/dev/null ; or command git symbolic-ref --short HEAD 2> /dev/null ; or command git rev-parse --short HEAD 2> /dev/null)
 
     if [ "$dirty" != "0" ]
       set_color -b normal


### PR DESCRIPTION
Add Git tag name as possible repository _reference name_

The new order is now:
- Tag name
- Branch name
- Commit short SHA-1
