### PR TITLE
Tag for active python virtual environments

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -28,6 +28,13 @@ function show_status -d "Function to show the current status"
     end
 end
 
+function show_virtualenv -d "Show active python virtuel environments"
+  if set -q VIRTUAL_ENV
+    set -l venvname (basename "$VIRTUAL_ENV")
+    prompt_segment normal white " ($venvname)"
+  end
+end
+
 ## Show user if not default
 function show_user -d "Show user"
   if [ "$USER" != "$default_user" -o -n "$SSH_CLIENT" ]
@@ -60,7 +67,7 @@ function show_prompt -d "Shows prompt with cue for current priv"
   else
     prompt_segment normal white " \$ "
     end
-  
+
   set_color normal
 end
 
@@ -68,6 +75,7 @@ end
 function fish_prompt
   set -g RETVAL $status
   show_status
+  show_virtualenv
   show_user
   show_pwd
   show_prompt

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -28,7 +28,7 @@ function show_status -d "Function to show the current status"
     end
 end
 
-function show_virtualenv -d "Show active python virtuel environments"
+function show_virtualenv -d "Show active python virtual environments"
   if set -q VIRTUAL_ENV
     set -l venvname (basename "$VIRTUAL_ENV")
     prompt_segment normal white " ($venvname)"


### PR DESCRIPTION
Since virtualfish does not add a tag to the prompt for active virtual environments you don't know when you're in an virtualenv.
So i added a tag to prompt to reflect active environments.

A tag for active environments looks like this:
![screen shot 2016-01-16 at 13 13 34](https://cloud.githubusercontent.com/assets/5154046/12372366/e7aaf4c2-bc53-11e5-8ec4-9a0bc189ce54.png)

Feel free to adjust the color values to better match the style of the theme.
