### PR TITLE
fix invalid option in the hostname

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -38,7 +38,7 @@ end
 ## Show user if not default
 function show_user -d "Show user"
   if [ "$USER" != "$default_user" -o -n "$SSH_CLIENT" ]
-    set -l host (hostname -s)
+    set -l host (hostname)
     set -l who (whoami)
     prompt_segment normal yellow " $who"
 


### PR DESCRIPTION
When I used cmorrell theme, occurs this error:

```
diogo at Sidarta in ~
» omf install cmorrell
Installing theme cmorrell
✔ theme cmorrell successfully installed.
hostname: invalid option -- 's'
Try 'hostname --help' for more information.
 diogo@ ~  $ 
```

I'm using [Void Linux](http://www.voidlinux.eu/), and version the hostname is:

```
 diogo@Sidarta ~  $ hostname --version
hostname (GNU coreutils) 8.25
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jim Meyering.

```

This PR remove the option -s in hostname command.

