### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -2,7 +2,7 @@
 function get_git_status -d "Gets the current git status"
   if command git rev-parse --is-inside-work-tree >/dev/null 2>&1
     set -l dirty (command git status -s --ignore-submodules=dirty | wc -l | sed -e 's/^ *//' -e 's/ *$//' 2> /dev/null)
-    set -l ref (command git describe --tags --exact-match ^/dev/null ; or command git symbolic-ref --short HEAD 2> /dev/null ; or command git rev-parse --short HEAD 2> /dev/null)
+    set -l ref (command git describe --tags --exact-match 2> /dev/null ; or command git symbolic-ref --short HEAD 2> /dev/null ; or command git rev-parse --short HEAD 2> /dev/null)
 
     if [ "$dirty" != "0" ]
       set_color -b normal


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618